### PR TITLE
Initial version of the github actions job that prepares files pages.

### DIFF
--- a/.github/workflows/publish-to-pages.yml
+++ b/.github/workflows/publish-to-pages.yml
@@ -1,0 +1,41 @@
+
+name: Publish HTML presentations from main to github pages.
+
+on:
+    workflow_dispatch:
+
+jobs:
+  build-presentations:
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/55-build-and-publish-to-pages-via-cicd'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2  # Ensures we have at least the previous commit for diffing
+
+      - name: Create Publish Directory
+        run: |
+          echo "PUBLISH_DIR=publish" >> $GITHUB_ENV
+          mkdir -p $PUBLISH_DIR
+          chmod -R 777 $PUBLISH_DIR  # Ensure write permissions
+
+      - name: Copy assets directories to the publish directory
+        run: |
+          find content -type d -name "assets" | while read file; do
+            assets_dir=${file#content/}
+            echo "Copying assets directory: $assets_dir to $PUBLISH_DIR/$assets_dir"
+            cp -r $file $PUBLISH_DIR/$assets_dir
+          done
+
+      - name: Convert Markdown to HTML and PDF using Marp CLI
+        run: |
+          find content -type f -name "*.md" | while read file; do
+            relative_path="${file#content/}"
+            output_dir="$PUBLISH_DIR/$(dirname "$relative_path")"
+            output_path_html="$output_dir/$(basename "${file%.md}.html")"
+
+            # Run Marp CLI without specifying a user to avoid permission issues
+            docker run --rm -v "$PWD:/workspace" -w /workspace ghcr.io/marp-team/marp-cli --allow-local-files "$file" --output "$output_path_html" --html
+          done


### PR DESCRIPTION
Build all html files, copy images and store everything in the publish dir. The job can only be triggered manually.